### PR TITLE
adding oneOf method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 target
 .idea
 *.iml
+.classpath
+.project
+.settings
+/target/
+bin

--- a/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
+++ b/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
@@ -552,6 +552,30 @@ public class VerbalExpression {
             }
             return this;
         }
+        
+        /**
+         * Adds an alternative expression to be matched
+         * based on an array of values
+         *
+         * @param pValues - the strings to be looked for
+         * @return this builder
+         */
+        public Builder oneOf(final String... pValues) {
+            if(pValues != null && pValues.length > 0) {
+        	this.add("(?:");
+        	for(int i = 0; i < pValues.length; i++) {
+        	    String value = pValues[i];
+        	    this.add("(?:");
+        	    this.add(value);
+        	    this.add(")");
+        	    if(i < pValues.length - 1) {
+        	        this.add("|");
+        	    }
+        	}
+        	this.add(")");
+            }
+            return this;
+        }
 
         /**
          * Adds capture - open brace to current position and closed to suffixes

--- a/src/test/java/ru/lanwen/verbalregex/BasicFunctionalityUnitTest.java
+++ b/src/test/java/ru/lanwen/verbalregex/BasicFunctionalityUnitTest.java
@@ -538,4 +538,45 @@ public class BasicFunctionalityUnitTest {
         assertThat(regexWithOneOrMore, matchesTo(empty));
         assertThat(regexWithOneOrMore, matchesExactly(empty));
     }
+    
+    @Test
+    public void testOneOf() {
+        VerbalExpression testRegex = new VerbalExpression.Builder()
+                .startOfLine()
+                .oneOf("abc", "def")
+                .build();
+
+        assertThat("Starts with abc or def", testRegex, matchesTo("defzzz"));
+        assertThat("Starts with abc or def", testRegex, matchesTo("abczzz"));
+        assertThat("Doesn't start with abc nor def", testRegex, not(matchesTo("xyzabc")));
+    }
+    
+    @Test
+    public void testOneOfWithCapture() {
+        VerbalExpression testRegex = regex()
+                .capture()
+                .oneOf("abc", "def")
+                .build();
+        assertThat("Starts with abc or def", testRegex, matchesTo("defzzz"));
+        assertThat("Starts with abc or def", testRegex, matchesTo("abczzz"));
+        assertThat("Doesn't start with abc or def", testRegex, not(matchesExactly("xyzabcefg")));
+
+        assertThat(testRegex.getText("xxxabcdefzzz", 1), equalTo("abcdef"));
+        assertThat(testRegex.getText("xxxdefzzz", 1), equalTo("def"));
+    }
+
+    @Test
+    public void testOneOfWithClosedCapture() {
+        VerbalExpression testRegex = regex()
+                .capture()
+                .oneOf("abc", "def")
+                .endCapt()
+                .build();
+        assertThat("Starts with abc or def", testRegex, matchesTo("defzzz"));
+        assertThat("Starts with abc or def", testRegex, matchesTo("abczzz"));
+        assertThat("Doesn't start with abc or def", testRegex, not(matchesExactly("xyzabcefg")));
+
+        assertThat(testRegex.getText("xxxabcdefzzz", 1), equalTo("abcdef"));
+        assertThat(testRegex.getText("xxxdefzzz", 1), equalTo("def"));
+    }
 }

--- a/src/test/java/ru/lanwen/verbalregex/RealWorldUnitTest.java
+++ b/src/test/java/ru/lanwen/verbalregex/RealWorldUnitTest.java
@@ -3,9 +3,8 @@ package ru.lanwen.verbalregex;
 import org.junit.Ignore;
 import org.junit.Test;
 
-
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
 import static ru.lanwen.verbalregex.VerbalExpression.regex;
 import static ru.lanwen.verbalregex.matchers.TestMatchMatcher.matchesTo;
 import static ru.lanwen.verbalregex.matchers.TestsExactMatcher.matchesExactly;
@@ -107,5 +106,16 @@ public class RealWorldUnitTest {
     @Test
     @Ignore("Planned in 1.3")
     public void captureWithName() throws Exception {
+    }
+    
+    @Test
+    public void testStarWarsMovies() {
+	VerbalExpression regex = VerbalExpression.regex()
+		.find("Star Wars: ")
+		.oneOf("The Phantom Menace", "Attack of the Clones", "Revenge of the Sith", 
+			"The Force Awakens", "A New Hope", "The Empire Strikes Back", "Return of the Jedi")
+		.build();
+	assertTrue(regex.test("Star Wars: The Empire Strikes Back"));
+	assertTrue(regex.test("Star Wars: Return of the Jedi"));
     }
 }


### PR DESCRIPTION
Adding a method called 'oneOf', which builds an or expression with an array of strings passed to it as parameters. This method can be used as an alternative to the already existing 'or' method when there is a wish to use more than two values at once. Furthermore, this method works nicely with the 'capture' method and does not present the problems that arise when we use the 'or' method with 'capture'.