### PR TITLE
renaming anythingBut method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can use *SNAPSHOT* dependency with adding to `pom.xml`:
 VerbalExpression testRegex = VerbalExpression.regex()
                                                 .startOfLine().then("http").maybe("s")
 	           				.then("://")
-	           				.maybe("www.").anythingButNot(" ")
+	           				.maybe("www.").anythingBut(" ")
 	           				.endOfLine()
 	           				.build();
 

--- a/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
+++ b/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
@@ -186,7 +186,7 @@ public class VerbalExpression {
          * @param pValue - the string not to match
          * @return this builder
          */
-        public Builder anythingButNot(final String pValue) {
+        public Builder anythingBut(final String pValue) {
             return this.add("(?:[^" + sanitize(pValue) + "]*)");
         }
 

--- a/src/test/java/ru/lanwen/verbalregex/BasicFunctionalityUnitTest.java
+++ b/src/test/java/ru/lanwen/verbalregex/BasicFunctionalityUnitTest.java
@@ -35,7 +35,7 @@ public class BasicFunctionalityUnitTest {
     public void testAnythingBut() {
         VerbalExpression testRegex = new VerbalExpression.Builder()
                 .startOfLine()
-                .anythingButNot("w")
+                .anythingBut("w")
                 .build();
 
         assertFalse("starts with w", testRegex.testExact("what"));
@@ -342,7 +342,7 @@ public class BasicFunctionalityUnitTest {
                 .maybe("s")
                 .then("://")
                 .then("www.")
-                .anythingButNot(" ")
+                .anythingBut(" ")
                 .add("com").build();
         assertEquals(testRegex.getText(testString), "https://www.google.com");
 

--- a/src/test/java/ru/lanwen/verbalregex/RealWorldUnitTest.java
+++ b/src/test/java/ru/lanwen/verbalregex/RealWorldUnitTest.java
@@ -21,7 +21,7 @@ public class RealWorldUnitTest {
                 .maybe("s")
                 .then("://")
                 .maybe("www.")
-                .anythingButNot(" ")
+                .anythingBut(" ")
                 .endOfLine()
                 .build();
 


### PR DESCRIPTION
The expression "anything but ..." already means "anything except for ...". Adding "not" to the end of this expression is a double negation that may confuse users.