### PR TITLE
maybe() method now accepts a builder as parameter

### DIFF
--- a/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
+++ b/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
@@ -1,10 +1,9 @@
 package ru.lanwen.verbalregex;
 
+import static java.lang.String.valueOf;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static java.lang.String.valueOf;
-import static ru.lanwen.verbalregex.VerbalExpression.regex;
 
 public class VerbalExpression {
 
@@ -191,7 +190,7 @@ public class VerbalExpression {
          * @return this builder
          */
         public Builder maybe(final Builder regex) {
-            return this.group().add(regex.build().toString()).endGr().add("?");
+            return this.group().add(regex).endGr().add("?");
         }
 
         /**

--- a/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
+++ b/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
@@ -170,6 +170,10 @@ public class VerbalExpression {
         public Builder maybe(final String pValue) {
             return this.then(pValue).add("?");
         }
+        
+        public Builder maybe(final Builder regex) {
+            return this.group().add(regex.build().toString()).endGr().add("?");
+        }
 
         /**
          * Add expression that matches anything (includes empty string)

--- a/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
+++ b/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
@@ -4,6 +4,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.lang.String.valueOf;
+import static ru.lanwen.verbalregex.VerbalExpression.regex;
 
 public class VerbalExpression {
 
@@ -171,6 +172,24 @@ public class VerbalExpression {
             return this.then(pValue).add("?");
         }
         
+        /**
+         * Add a regex to the expression that might appear once (or not)
+         * Example:
+         * The following matches all names that have a prefix or not.
+         * VerbalExpression.Builder namePrefix = regex().oneOf("Mr.", "Ms.");
+	 * VerbalExpression name = regex()
+	 *	.maybe(namePrefix)
+	 *	.space()
+	 *	.zeroOrMore()
+	 *	.word()
+	 *	.oneOrMore()
+	 *	.build();
+         * regex.test("Mr. Bond/")    //true
+         * regex.test("James")   //true
+         *
+         * @param pValue - the string to be looked for
+         * @return this builder
+         */
         public Builder maybe(final Builder regex) {
             return this.group().add(regex.build().toString()).endGr().add("?");
         }

--- a/src/test/java/ru/lanwen/verbalregex/BasicFunctionalityUnitTest.java
+++ b/src/test/java/ru/lanwen/verbalregex/BasicFunctionalityUnitTest.java
@@ -579,4 +579,20 @@ public class BasicFunctionalityUnitTest {
         assertThat(testRegex.getText("xxxabcdefzzz", 1), equalTo("abcdef"));
         assertThat(testRegex.getText("xxxdefzzz", 1), equalTo("def"));
     }
+    
+    @Test
+    public void shouldAddMaybeWithOneOfFromAnotherBuilder() {
+	VerbalExpression.Builder namePrefix = regex().oneOf("Mr.", "Ms.");
+	VerbalExpression name = regex()
+		.maybe(namePrefix)
+		.space()
+		.zeroOrMore()
+		.word()
+		.oneOrMore()
+		.build();
+	
+	assertThat("Is a name with prefix", name, matchesTo("Mr. Bond"));
+	assertThat("Is a name without prefix", name, matchesTo("James"));
+	
+    }
 }


### PR DESCRIPTION
I propose that all Builder methods which accept a string as parameter should have another version that accepts another Builder as parameter. This would allow users to break their expressions into smaller expressions, thus making their code more readable and maintainable. I built a test showing an example of an expression built with the oneOf() method being passed as the parameter for the maybe() method (with the current code this would not be possible, as the contents of the oneOf() expression would all be escaped with \\).

If you guys think this is a good idea, I will open another PR implementing the same idea for all other methods of the Builder class.