### PR TITLE
Fixing zeroOrMore() and oneOrMore() methods

### DIFF
--- a/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
+++ b/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
@@ -473,7 +473,7 @@ public class VerbalExpression {
          */
         public Builder multiple(final String pValue, final int... count) {
             if (count == null) {
-                return this.then(pValue).oneOrMore();
+                return this.oneOrMore(pValue);
             }
             switch (count.length) {
                 case 1:
@@ -481,7 +481,7 @@ public class VerbalExpression {
                 case 2:
                     return this.then(pValue).count(count[0], count[1]);
                 default:
-                    return this.then(pValue).oneOrMore();
+                    return this.oneOrMore(pValue);
             }
         }
 
@@ -493,8 +493,8 @@ public class VerbalExpression {
          * @return this builder
          * @since 1.2
          */
-        public Builder oneOrMore() {
-            return this.add("+");
+        public Builder oneOrMore(String pValue) {
+            return this.then(pValue).add("+");
         }
 
         /**
@@ -504,8 +504,8 @@ public class VerbalExpression {
          * @return this builder
          * @since 1.2
          */
-        public Builder zeroOrMore() {
-            return this.add("*");
+        public Builder zeroOrMore(String pValue) {
+            return this.then(pValue).add("*");
         }
 
         /**

--- a/src/test/java/ru/lanwen/verbalregex/BasicFunctionalityUnitTest.java
+++ b/src/test/java/ru/lanwen/verbalregex/BasicFunctionalityUnitTest.java
@@ -492,7 +492,7 @@ public class BasicFunctionalityUnitTest {
 
     @Test
     public void oneOreMoreSameAsAtLeast1() throws Exception {
-        VerbalExpression regexWithOneOrMore = regex().find("a").oneOrMore().build();
+        VerbalExpression regexWithOneOrMore = regex().oneOrMore("a").build();
 
         String matched = "aaaaaa";
         String oneMatchedExactly = "a";
@@ -524,7 +524,7 @@ public class BasicFunctionalityUnitTest {
 
     @Test
     public void zeroOreMoreSameAsAtLeast0() throws Exception {
-        VerbalExpression regexWithOneOrMore = regex().find("a").zeroOrMore().build();
+        VerbalExpression regexWithOneOrMore = regex().zeroOrMore("a").build();
 
         String matched = "aaaaaa";
         String oneMatchedExactly = "a";
@@ -585,10 +585,8 @@ public class BasicFunctionalityUnitTest {
 	VerbalExpression.Builder namePrefix = regex().oneOf("Mr.", "Ms.");
 	VerbalExpression name = regex()
 		.maybe(namePrefix)
-		.space()
-		.zeroOrMore()
-		.word()
-		.oneOrMore()
+		.zeroOrMore(" ")
+		.add("\\w+")
 		.build();
 	
 	assertThat("Is a name with prefix", name, matchesTo("Mr. Bond"));

--- a/src/test/java/ru/lanwen/verbalregex/NegativeCasesTest.java
+++ b/src/test/java/ru/lanwen/verbalregex/NegativeCasesTest.java
@@ -71,7 +71,7 @@ public class NegativeCasesTest {
         VerbalExpression regex = regex().multiple("some", null).build();
 
         assertThat("Multiply with null should be equal to oneOrMore",
-                regex.toString(), equalTo(regex().find("some").oneOrMore().build().toString()));
+                regex.toString(), equalTo(regex().oneOrMore("some").build().toString()));
     }
 
     @Test
@@ -79,7 +79,7 @@ public class NegativeCasesTest {
         VerbalExpression regex = regex().multiple("some", 1, 2, 3).build();
 
         assertThat("Multiply with 3 args should be equal to oneOrMore",
-                regex.toString(), equalTo(regex().find("some").oneOrMore().build().toString()));
+                regex.toString(), equalTo(regex().oneOrMore("some").build().toString()));
     }
 
     @Test(expected = java.util.regex.PatternSyntaxException.class)

--- a/src/test/java/ru/lanwen/verbalregex/RealWorldUnitTest.java
+++ b/src/test/java/ru/lanwen/verbalregex/RealWorldUnitTest.java
@@ -57,22 +57,22 @@ public class RealWorldUnitTest {
         String logLine = "3\t4\t1\thttp://localhost:20001\t1\t63528800\t0\t63528800\t1000000000\t0\t63528800\tSTR1";
 
         VerbalExpression regex = regex()
-                .capt().digit().oneOrMore().endCapture().tab()
-                .capt().digit().oneOrMore().endCapture().tab()
+                .capt().add("\\d+").endCapture().tab()
+                .capt().add("\\d+").endCapture().tab()
                 .capt().range("0", "1").count(1).endCapture().tab()
                 .capt().find("http://localhost:20").digit().count(3).endCapture().tab()
                 .capt().range("0", "1").count(1).endCapture().tab()
-                .capt().digit().oneOrMore().endCapture().tab()
+                .capt().add("\\d+").endCapture().tab()
                 .capt().range("0", "1").count(1).endCapture().tab()
-                .capt().digit().oneOrMore().endCapture().tab()
-                .capt().digit().oneOrMore().endCapture().tab()
+                .capt().add("\\d+").endCapture().tab()
+                .capt().add("\\d+").endCapture().tab()
                 .capt().range("0", "1").count(1).endCapture().tab()
-                .capt().digit().oneOrMore().endCapture().tab()
+                .capt().add("\\d+").endCapture().tab()
                 .capt().find("STR").range("0", "2").count(1).endCapture().build();
 
         assertThat(regex, matchesExactly(logLine));
 
-        VerbalExpression.Builder digits = regex().capt().digit().oneOrMore().endCapt().tab();
+        VerbalExpression.Builder digits = regex().capt().add("\\d+").endCapt().tab();
         VerbalExpression.Builder range = regex().capt().range("0", "1").count(1).endCapt().tab();
         VerbalExpression.Builder host = regex().capt().find("http://localhost:20").digit().count(3).endCapt().tab();
         VerbalExpression.Builder fake = regex().capt().find("STR").range("0", "2").count(1);


### PR DESCRIPTION
This is a fix for issue https://github.com/VerbalExpressions/JavaVerbalExpressions/issues/36.

zeroOrMore() and oneOrMore() methods now accept a parameter just like the maybe method() in order to generate correct expressions.

As a temporary side effect, it is no longer possible to do things like regex().digit().zeroOrMore(). I intend to fix this in a future PR.