### PR TITLE
Added missing Macintosh line break

### DIFF
--- a/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
+++ b/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
@@ -233,7 +233,7 @@ public class VerbalExpression {
          * @return this builder
          */
         public Builder lineBreak() {
-            return this.add("(?:\\n|(?:\\r\\n))");
+            return this.add("(?:\\n|(?:\\r\\n)|(?:\\r\\r))");
         }
 
         /**

--- a/src/test/java/ru/lanwen/verbalregex/BasicFunctionalityUnitTest.java
+++ b/src/test/java/ru/lanwen/verbalregex/BasicFunctionalityUnitTest.java
@@ -179,6 +179,18 @@ public class BasicFunctionalityUnitTest {
     }
 
     @Test
+    public void testMacintoshLineBreak() {
+        VerbalExpression testRegex = new VerbalExpression.Builder()
+                .startOfLine()
+                .then("abc")
+                .lineBreak()
+                .then("def")
+                .build();
+
+        assertThat("abc then line break then def", testRegex, matchesTo("abc\r\rdef"));
+    }
+
+    @Test
     public void testBr() {
         VerbalExpression testRegexBr = new VerbalExpression.Builder()
                 .startOfLine()


### PR DESCRIPTION
Macintosh line break was originally "\r\r". A so-called "universal" line-break matcher should match this as it can be encountered in real world.