### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ VerbalExpressions is a Java library that helps to construct difficult regular ex
 
 
 
-##Getting Started
+## Getting Started
 
 Maven Dependency:
 
@@ -30,7 +30,7 @@ You can use *SNAPSHOT* dependency with adding to `pom.xml`:
 </repositories>
 ```
 
-##Examples
+## Examples
 ```java
 VerbalExpression testRegex = VerbalExpression.regex()
                                                 .startOfLine().then("http").maybe("s")


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
