### PR TITLE
Fixing squid:S3599

### DIFF
--- a/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
+++ b/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
@@ -20,15 +20,16 @@ public class VerbalExpression {
         private StringBuilder suffixes = new StringBuilder();
         private int modifiers = Pattern.MULTILINE;
 
-        private static final Map<Character, Integer> SYMBOL_MAP = new HashMap<Character, Integer>() {{
-            put('d', Pattern.UNIX_LINES);
-            put('i', Pattern.CASE_INSENSITIVE);
-            put('x', Pattern.COMMENTS);
-            put('m', Pattern.MULTILINE);
-            put('s', Pattern.DOTALL);
-            put('u', Pattern.UNICODE_CASE);
-            put('U', Pattern.UNICODE_CHARACTER_CLASS);
-        }};
+        private static final Map<Character, Integer> SYMBOL_MAP = new HashMap<>();
+        static {
+        	SYMBOL_MAP.put('d', Pattern.UNIX_LINES);
+        	SYMBOL_MAP.put('i', Pattern.CASE_INSENSITIVE);
+        	SYMBOL_MAP.put('x', Pattern.COMMENTS);
+        	SYMBOL_MAP.put('m', Pattern.MULTILINE);
+        	SYMBOL_MAP.put('s', Pattern.DOTALL);
+        	SYMBOL_MAP.put('u', Pattern.UNICODE_CASE);
+        	SYMBOL_MAP.put('U', Pattern.UNICODE_CHARACTER_CLASS);
+        }
 
         /**
          * Package private. Use {@link #regex()} to build a new one


### PR DESCRIPTION
squid:s3599: Double Brace Initialization should not be used

> Because Double Brace Initialization (DBI) creates an anonymous class with a reference to the instance of the owning object, 
> its use can lead to memory leaks if the anonymous inner class is returned and held by other objects. Even when there's no leak, DBI is so obscure 
> that it's bound to confuse most maintainers. 

Using diamond operator