### PR TITLE
Fixing the handling of (unmatched) optional capture groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 sudo: false
 
 jdk:
- - openjdk11
+ - openjdk8
 
 install:
   - mvn --settings .travis/settings.xml install -DskipTests=true -Dgpg.skip -Dmaven.javadoc.skip=true -B -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 sudo: false
 
 jdk:
- - oraclejdk8
+ - openjdk11
 
 install:
   - mvn --settings .travis/settings.xml install -DskipTests=true -Dgpg.skip -Dmaven.javadoc.skip=true -B -V

--- a/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
+++ b/src/main/java/ru/lanwen/verbalregex/VerbalExpression.java
@@ -762,7 +762,10 @@ public class VerbalExpression {
         Matcher m = pattern.matcher(toTest);
         StringBuilder result = new StringBuilder();
         while (m.find()) {
-            result.append(m.group(group));
+            String groupValue = m.group(group);
+            if (groupValue != null) {
+                result.append(groupValue);
+            }
         }
         return result.toString();
     }
@@ -781,7 +784,10 @@ public class VerbalExpression {
         Matcher m = pattern.matcher(toTest);
         StringBuilder result = new StringBuilder();
         while (m.find()) {
-            result.append(m.group(group));
+            String groupValue = m.group(group);
+            if (groupValue != null) {
+                result.append(groupValue);
+            }
         }
         return result.toString();
     }

--- a/src/test/java/ru/lanwen/verbalregex/BasicFunctionalityUnitTest.java
+++ b/src/test/java/ru/lanwen/verbalregex/BasicFunctionalityUnitTest.java
@@ -497,9 +497,9 @@ public class BasicFunctionalityUnitTest {
         assertThat("Starts with abc or def", testRegex, matchesTo("abczzz"));
         assertThat("Doesn't start with abc or def", testRegex, not(matchesExactly("xyzabcefg")));
 
-        assertThat(testRegex.getText("xxxabcdefzzz", 1), equalTo("abcnull"));
-        assertThat(testRegex.getText("xxxdefzzz", 1), equalTo("null"));
-        assertThat(testRegex.getText("xxxabcdefzzz", 1), equalTo("abcnull"));
+        assertThat(testRegex.getText("xxxabcdefzzz", 1), equalTo("abc"));
+        assertThat(testRegex.getText("xxxdefzzz", 1), equalTo(""));
+        assertThat(testRegex.getText("xxxabcdefzzz", 1), equalTo("abc"));
     }
 
     @Test
@@ -516,11 +516,11 @@ public class BasicFunctionalityUnitTest {
                 testRegex, not(matchesExactly("xyzabcefg")));
 
         assertThat(testRegex.getText("xxxabcdefzzz", captureName),
-                equalTo("abcnull"));
+                equalTo("abc"));
         assertThat(testRegex.getText("xxxdefzzz", captureName),
-                equalTo("null"));
+                equalTo(""));
         assertThat(testRegex.getText("xxxabcdefzzz", captureName),
-                equalTo("abcnull"));
+                equalTo("abc"));
     }
 
     @Test
@@ -535,9 +535,9 @@ public class BasicFunctionalityUnitTest {
         assertThat("Starts with abc or def", testRegex, matchesTo("abczzz"));
         assertThat("Doesn't start with abc or def", testRegex, not(matchesExactly("xyzabcefg")));
 
-        assertThat(testRegex.getText("xxxabcdefzzz", 1), equalTo("abcnull"));
-        assertThat(testRegex.getText("xxxdefzzz", 1), equalTo("null"));
-        assertThat(testRegex.getText("xxxabcdefzzz", 1), equalTo("abcnull"));
+        assertThat(testRegex.getText("xxxabcdefzzz", 1), equalTo("abc"));
+        assertThat(testRegex.getText("xxxdefzzz", 1), equalTo(""));
+        assertThat(testRegex.getText("xxxabcdefzzz", 1), equalTo("abc"));
     }
 
     @Test
@@ -555,11 +555,11 @@ public class BasicFunctionalityUnitTest {
                 testRegex, not(matchesExactly("xyzabcefg")));
 
         assertThat(testRegex.getText("xxxabcdefzzz", captureName),
-                equalTo("abcnull"));
+                equalTo("abc"));
         assertThat(testRegex.getText("xxxdefzzz", captureName),
-                equalTo("null"));
+                equalTo(""));
         assertThat(testRegex.getText("xxxabcdefzzz", captureName),
-                equalTo("abcnull"));
+                equalTo("abc"));
     }
 
     @Test

--- a/src/test/java/ru/lanwen/verbalregex/RealWorldUnitTest.java
+++ b/src/test/java/ru/lanwen/verbalregex/RealWorldUnitTest.java
@@ -164,7 +164,6 @@ public class RealWorldUnitTest {
                 .build();
         final String testString = "c";
         assertThat(expression, matchesExactly(testString));
-        assertThat(expression.getText("c", "optionalCapture"), not(equalTo("null")));
         assertThat(expression.getText("c", "optionalCapture"), equalTo(""));
     }
 }

--- a/src/test/java/ru/lanwen/verbalregex/RealWorldUnitTest.java
+++ b/src/test/java/ru/lanwen/verbalregex/RealWorldUnitTest.java
@@ -4,6 +4,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static ru.lanwen.verbalregex.VerbalExpression.regex;
@@ -148,5 +149,22 @@ public class RealWorldUnitTest {
 
         assertThat(some,
                 equalTo(expression.getText(lineBreak + some + text, captureName)));
+    }
+
+    @Test
+    public void missingOptionalCaptureGroupReturnsEmptyStringNotStringContainingNullLiteral() {
+        final VerbalExpression expression = VerbalExpression.regex().
+                startOfLine()
+                .capture("optionalCapture")
+                .oneOf("a", "b")
+                .endCapture()
+                .count(0, 1)
+                .then("c")
+                .endOfLine()
+                .build();
+        final String testString = "c";
+        assertThat(expression, matchesExactly(testString));
+        assertThat(expression.getText("c", "optionalCapture"), not(equalTo("null")));
+        assertThat(expression.getText("c", "optionalCapture"), equalTo(""));
     }
 }


### PR DESCRIPTION
I ran into an issue where I have a capture group defined, that is actually optional. Whenever that group cannot be matched (which is ok since it is optional) the `regex.getText(testString, "optionalCaptureGroupName")` call would return a string literal `"null"` instead of an empty string `""`.

This PR provides a test showcasing the problem and a code adaption fixing the issue.