### PR TITLE
Add a module info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,31 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.moditect</groupId>
+                <artifactId>moditect-maven-plugin</artifactId>
+                <version>1.0.0.Final</version>
+                <executions>
+                    <execution>
+                        <id>add-module-infos</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>add-module-info</goal>
+                        </goals>
+                        <configuration>
+                            <jvmVersion>9</jvmVersion>
+                            <module>
+                                <moduleInfo>
+                                    <name>ru.lanwen.verbalregex</name>
+                                    <exports>
+                                        ru.lanwen.verbalregex;
+                                    </exports>
+                                </moduleInfo>
+                            </module>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This adds a full module-info descriptor for users of Java 9+. It is packaged as a multi-release Jar so there should be no breakage.

This is needed for

* Using `jlink` when this appears as a transitive or direct dependency.
* Publishing an artifact which depends on this artifact. The social convention is without a module-info or Automatic-Module-Name that module names are considered unstable.